### PR TITLE
[EVH] Check all descendants instead of children of lights for emitters

### DIFF
--- a/src/handler/EVHEvent/loader/modules/main.luau
+++ b/src/handler/EVHEvent/loader/modules/main.luau
@@ -476,7 +476,7 @@ local function addLight(vehicleData: types.vehicle, light: Instance)
 		for _, color in vehicleData.configuration.lightSettings.colors do
 			table.insert(colorNames, color.name)
 		end
-		for _, lighto in light:GetChildren() do
+		for _, lighto in light:GetDescendants() do
 			if lighto:IsA("Light") then
 				lighto.Enabled = false
 				lighto:SetAttribute("defaultBrightness", lighto.Brightness)


### PR DESCRIPTION
Updated 479 to use :GetDescendants() rather than :GetChildren() to allow lights not directly parented to the object to be used.